### PR TITLE
feat(): add explicit zip folder on script nodejs after installing deps

### DIFF
--- a/examples/nodejs10.x/install.sh
+++ b/examples/nodejs10.x/install.sh
@@ -12,3 +12,9 @@ docker run --rm -v "$PWD"/dependencies:/lambda/opt lambci/yumda:2 yum install -y
 # OR
 
 # sls invoke local --docker -f hello-world
+
+# To prepare to deploy:
+
+# cd dependencies
+# zip -yr ../dependencies.zip .
+# cd ..


### PR DESCRIPTION
Signed-off-by: Erick Wendel <erick.workspace@gmail.com>

On Node.js apps was super hard to me figure out that to zip my dependencies I must use another flag. I put this on `install.sh`  file to explicit it